### PR TITLE
Builds fine with base-4.8.

### DIFF
--- a/servant-persistent.cabal
+++ b/servant-persistent.cabal
@@ -25,7 +25,7 @@ executable perservant
                      , Models
                      , Api
   -- other-extensions:    
-  build-depends:       base >=4.7 && <4.8
+  build-depends:       base >=4.7 && <4.9
                      , servant >= 0.4 && < 0.5
                      , servant-server >= 0.4 && < 0.5
                      , persistent >= 2.1 && < 2.2


### PR DESCRIPTION
Update the version bounds for `base`.  I am able to build it successfully with ghc-7.10.1.