### PR TITLE
add `UserDbSpec.hs` to demonstrate how to use the DB within Hspec

### DIFF
--- a/servant-persistent.cabal
+++ b/servant-persistent.cabal
@@ -22,14 +22,14 @@ executable perservant
         Main.hs
     build-depends:
         base >=4.7 && <4.9
-      , servant-persistent 
+      , servant-persistent
       , persistent-postgresql
       , wai
       , warp
       , monad-logger
       , safe
     hs-source-dirs:
-        app   
+        app
     default-language:
         Haskell2010
 
@@ -43,7 +43,7 @@ library
       , Models
       , Api
       , Api.User
-    build-depends: 
+    build-depends:
         base >= 4.7 && < 4.9
       , aeson
       , bytestring
@@ -71,11 +71,18 @@ test-suite servant-persistent-test
         Spec.hs
     other-modules:
         ApiSpec
+        UserDbSpec
     build-depends:
         base
+      , persistent
+      , persistent-postgresql
       , servant-persistent
+      , servant >= 0.7 && < 0.8
+      , servant-server >= 0.7 && < 0.8
       , QuickCheck
       , hspec
+      , mtl
+      , transformers
     ghc-options:
         -threaded -rtsopts -with-rtsopts=-N
     default-language:

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -62,7 +62,7 @@ setLogger Production = logStdout
 -- deployment application.
 makePool :: Environment -> IO ConnectionPool
 makePool Test =
-    runNoLoggingT (createPostgresqlPool (connStr "test") (envPool Test))
+    runNoLoggingT (createPostgresqlPool (connStr "-test") (envPool Test))
 makePool Development =
     runStdoutLoggingT (createPostgresqlPool (connStr "") (envPool Development))
 makePool Production = do

--- a/src/Models.hs
+++ b/src/Models.hs
@@ -26,7 +26,7 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 User json
     name String
     email String
-    deriving Show
+    deriving Show Eq
 |]
 
 doMigrations :: SqlPersistT IO ()

--- a/test/UserDbSpec.hs
+++ b/test/UserDbSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeOperators              #-}
+
+module UserDbSpec where
+
+import           Test.Hspec
+import           Test.QuickCheck
+
+import           Control.Monad.Except      (runExceptT)
+import           Control.Monad.Reader      (runReaderT)
+
+import           Servant
+import           Database.Persist.Types      (Filter)
+import           Database.Persist.Sql        (ConnectionPool, transactionUndo)
+import           Database.Persist.Postgresql (Entity (..), fromSqlKey, insert,
+                                              selectFirst, selectList, deleteWhere,
+                                              (==.), runSqlPool)
+
+import           Config (App (..), Config (..), Environment (..), makePool)
+import           Models
+import           Api.User
+
+
+runAppToIO :: Config -> App a -> IO a
+runAppToIO config app = do
+  result <- runExceptT $ runReaderT (runApp app) config
+  case result of
+    Left err -> error $ show err
+    Right a  -> return a
+
+setupTeardown :: (Config -> IO a) -> IO ()
+setupTeardown runTestsWith = do
+  pool <- makePool Test
+  migrateDb pool
+  runTestsWith $ Config { getPool = pool, getEnv = Test }
+  cleanDb pool
+  where
+    migrateDb :: ConnectionPool -> IO ()
+    migrateDb pool = runSqlPool doMigrations pool
+
+    cleanDb :: ConnectionPool -> IO ()
+    cleanDb = deleteAllUsers
+
+    deleteAllUsers :: ConnectionPool -> IO ()
+    deleteAllUsers pool = do
+      flip runSqlPool pool $ do
+        deleteWhere ([] :: [Filter User])
+
+
+-- for more detail, see `src/Config.hs`, but this assumes you have...
+--   1. a Postgres `test` user
+--   2. a `perservant-test` DB
+spec :: Spec
+spec = around setupTeardown $ do
+  describe "User" $ do
+    it "singleUser fetches User by name" $ \config -> do
+      let user = User "username" "email"
+      dbUser <- runAppToIO config $ do
+        runDb $ insert user
+        Entity _ user <- singleUser "username"
+        return user
+      dbUser `shouldBe` user


### PR DESCRIPTION
Thank you so much for this repo (and the accompanying blog post)! It's been a *huge* help.

I'm really new to Haskell, so my logic is likely not the cleanest, but I put together your suggestions from #9 to hit the DB from a test, and wanted to contribute back my results.

One question:

Is there a way to use `transactionUndo` (from `Database.Persist.Sql`) to roll back the effects of a test, rather than resorting to my `deleteAllUsers` function? I've tried a number of things, but can't quite figure out how to get it where it needs to be. Would greatly appreciate any suggestions!