### PR TITLE
Use text in entity def

### DIFF
--- a/servant-persistent.cabal
+++ b/servant-persistent.cabal
@@ -60,6 +60,7 @@ library
       , wai
       , wai-extra
       , warp
+      , text
 
 
 test-suite servant-persistent-test

--- a/src/Api/User.hs
+++ b/src/Api/User.hs
@@ -16,10 +16,11 @@ import           Servant.JS                  (vanillaJS, writeJSForAPI)
 
 import           Config                      (App (..), Config (..))
 import           Models
+import           Data.Text (Text)
 
 type UserAPI =
          "users" :> Get '[JSON] [Entity User]
-    :<|> "users" :> Capture "name" String :> Get '[JSON] (Entity User)
+    :<|> "users" :> Capture "name" Text :> Get '[JSON] (Entity User)
     :<|> "users" :> ReqBody '[JSON] User :> Post '[JSON] Int64
 
 -- | The server that runs the UserAPI
@@ -32,7 +33,7 @@ allUsers =
     runDb (selectList [] [])
 
 -- | Returns a user by name or throws a 404 error.
-singleUser :: String -> App (Entity User)
+singleUser :: Text -> App (Entity User)
 singleUser str = do
     maybeUser <- runDb (selectFirst [UserName ==. str] [])
     case maybeUser of

--- a/src/Models.hs
+++ b/src/Models.hs
@@ -21,11 +21,12 @@ import           Database.Persist.TH  (mkMigrate, mkPersist, persistLowerCase,
 import           GHC.Generics         (Generic)
 
 import           Config
+import           Data.Text (Text)
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 User json
-    name String
-    email String
+    name Text
+    email Text
     deriving Show Eq
 |]
 


### PR DESCRIPTION
Change the `User` entity definition to use `Text`, not `String`, per issue #10.

It seems to me that `Capture "name" String` should be changed to `Capture "name" T.Text`, so that we don't have to convert that from `String` to `Text`, but doing so led to some errors that I could not solve.

I'm glad to keep working on this to get to the idiomatic solution, with some help. ;)