### PR TITLE
User db specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,14 @@ before_install:
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
+services:
+- postgresql
+
+before_script:
+- psql -c 'create database test;' -U postgres
+- psql -c 'create role test LOGIN CREATEDB;' -U postgres
+- psql -c 'create database "perservant-test";' -U test
+
 # This line does all of the work: installs GHC if necessary, build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.

--- a/servant-persistent.cabal
+++ b/servant-persistent.cabal
@@ -22,14 +22,14 @@ executable perservant
         Main.hs
     build-depends:
         base >=4.7 && <4.9
-      , servant-persistent 
+      , servant-persistent
       , persistent-postgresql
       , wai
       , warp
       , monad-logger
       , safe
     hs-source-dirs:
-        app   
+        app
     default-language:
         Haskell2010
 
@@ -43,7 +43,7 @@ library
       , Models
       , Api
       , Api.User
-    build-depends: 
+    build-depends:
         base >= 4.7 && < 4.9
       , aeson
       , bytestring
@@ -71,11 +71,18 @@ test-suite servant-persistent-test
         Spec.hs
     other-modules:
         ApiSpec
+        UserDbSpec
     build-depends:
         base
+      , persistent
+      , persistent-postgresql
       , servant-persistent
+      , servant >= 0.7 && < 0.8
+      , servant-server >= 0.7 && < 0.8
       , QuickCheck
       , hspec
+      , mtl
+      , transformers
     ghc-options:
         -threaded -rtsopts -with-rtsopts=-N
     default-language:

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -62,7 +62,7 @@ setLogger Production = logStdout
 -- deployment application.
 makePool :: Environment -> IO ConnectionPool
 makePool Test =
-    runNoLoggingT (createPostgresqlPool (connStr "test") (envPool Test))
+    runNoLoggingT (createPostgresqlPool (connStr "-test") (envPool Test))
 makePool Development =
     runStdoutLoggingT (createPostgresqlPool (connStr "") (envPool Development))
 makePool Production = do

--- a/src/Models.hs
+++ b/src/Models.hs
@@ -26,7 +26,7 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 User json
     name String
     email String
-    deriving Show
+    deriving Show Eq
 |]
 
 doMigrations :: SqlPersistT IO ()

--- a/test/UserDbSpec.hs
+++ b/test/UserDbSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeOperators              #-}
+
+module UserDbSpec where
+
+import           Test.Hspec
+import           Test.QuickCheck
+
+import           Control.Monad.Except      (runExceptT)
+import           Control.Monad.Reader      (runReaderT)
+
+import           Servant
+import           Database.Persist.Types      (Filter)
+import           Database.Persist.Sql        (ConnectionPool, transactionUndo)
+import           Database.Persist.Postgresql (Entity (..), fromSqlKey, insert,
+                                              selectFirst, selectList, deleteWhere,
+                                              (==.), runSqlPool)
+
+import           Config (App (..), Config (..), Environment (..), makePool)
+import           Models
+import           Api.User
+
+
+runAppToIO :: Config -> App a -> IO a
+runAppToIO config app = do
+  result <- runExceptT $ runReaderT (runApp app) config
+  case result of
+    Left err -> error $ show err
+    Right a  -> return a
+
+setupTeardown :: (Config -> IO a) -> IO ()
+setupTeardown runTestsWith = do
+  pool <- makePool Test
+  migrateDb pool
+  runTestsWith $ Config { getPool = pool, getEnv = Test }
+  cleanDb pool
+  where
+    migrateDb :: ConnectionPool -> IO ()
+    migrateDb pool = runSqlPool doMigrations pool
+
+    cleanDb :: ConnectionPool -> IO ()
+    cleanDb = deleteAllUsers
+
+    deleteAllUsers :: ConnectionPool -> IO ()
+    deleteAllUsers pool = do
+      flip runSqlPool pool $ do
+        deleteWhere ([] :: [Filter User])
+
+
+-- for more detail, see `src/Config.hs`, but this assumes you have...
+--   1. a Postgres `test` user
+--   2. a `perservant-test` DB
+spec :: Spec
+spec = around setupTeardown $ do
+  describe "User" $ do
+    it "singleUser fetches User by name" $ \config -> do
+      let user = User "username" "email"
+      dbUser <- runAppToIO config $ do
+        runDb $ insert user
+        Entity _ user <- singleUser "username"
+        return user
+      dbUser `shouldBe` user

--- a/test/UserDbSpec.hs
+++ b/test/UserDbSpec.hs
@@ -1,63 +1,60 @@
-{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE TypeOperators #-}
 
 module UserDbSpec where
 
-import           Test.Hspec
-import           Test.QuickCheck
+import Test.Hspec
+import Test.QuickCheck
 
-import           Control.Monad.Except      (runExceptT)
-import           Control.Monad.Reader      (runReaderT)
+import Control.Monad.Except (runExceptT)
+import Control.Monad.Reader (runReaderT)
 
-import           Servant
-import           Database.Persist.Types      (Filter)
-import           Database.Persist.Sql        (ConnectionPool, transactionUndo)
-import           Database.Persist.Postgresql (Entity (..), fromSqlKey, insert,
-                                              selectFirst, selectList, deleteWhere,
-                                              (==.), runSqlPool)
+import Database.Persist.Postgresql
+       (Entity(..), (==.), deleteWhere, fromSqlKey, insert, runSqlPool,
+        selectFirst, selectList)
+import Database.Persist.Sql (ConnectionPool, transactionUndo)
+import Database.Persist.Types (Filter)
+import Servant
 
-import           Config (App (..), Config (..), Environment (..), makePool)
-import           Models
-import           Api.User
-
+import Api.User
+import Config (App(..), Config(..), Environment(..), makePool)
+import Models
 
 runAppToIO :: Config -> App a -> IO a
 runAppToIO config app = do
-  result <- runExceptT $ runReaderT (runApp app) config
-  case result of
-    Left err -> error $ show err
-    Right a  -> return a
+    result <- runExceptT $ runReaderT (runApp app) config
+    case result of
+        Left err -> error $ show err
+        Right a -> return a
 
 setupTeardown :: (Config -> IO a) -> IO ()
 setupTeardown runTestsWith = do
-  pool <- makePool Test
-  migrateDb pool
-  runTestsWith $ Config { getPool = pool, getEnv = Test }
-  cleanDb pool
+    pool <- makePool Test
+    migrateDb pool
+    runTestsWith $ Config {getPool = pool, getEnv = Test}
+    cleanDb pool
   where
     migrateDb :: ConnectionPool -> IO ()
     migrateDb pool = runSqlPool doMigrations pool
-
     cleanDb :: ConnectionPool -> IO ()
     cleanDb = deleteAllUsers
-
     deleteAllUsers :: ConnectionPool -> IO ()
     deleteAllUsers pool = do
-      flip runSqlPool pool $ do
-        deleteWhere ([] :: [Filter User])
-
+        flip runSqlPool pool $ do deleteWhere ([] :: [Filter User])
 
 -- for more detail, see `src/Config.hs`, but this assumes you have...
 --   1. a Postgres `test` user
 --   2. a `perservant-test` DB
 spec :: Spec
-spec = around setupTeardown $ do
-  describe "User" $ do
-    it "singleUser fetches User by name" $ \config -> do
-      let user = User "username" "email"
-      dbUser <- runAppToIO config $ do
-        runDb $ insert user
-        Entity _ user <- singleUser "username"
-        return user
-      dbUser `shouldBe` user
+spec =
+    around setupTeardown $ do
+        describe "User" $ do
+            it "singleUser fetches User by name" $ \config -> do
+                let user = User "username" "email"
+                dbUser <-
+                    runAppToIO config $ do
+                        runDb $ insert user
+                        Entity _ user <- singleUser "username"
+                        return user
+                dbUser `shouldBe` user

--- a/test/UserDbSpec.hs
+++ b/test/UserDbSpec.hs
@@ -7,6 +7,7 @@ module UserDbSpec where
 import Test.Hspec
 import Test.QuickCheck
 
+import Control.Exception (throwIO)
 import Control.Monad.Except (runExceptT)
 import Control.Monad.Reader (runReaderT)
 
@@ -25,7 +26,7 @@ runAppToIO :: Config -> App a -> IO a
 runAppToIO config app = do
     result <- runExceptT $ runReaderT (runApp app) config
     case result of
-        Left err -> error $ show err
+        Left err -> throwIO err
         Right a -> return a
 
 setupTeardown :: (Config -> IO a) -> IO ()


### PR DESCRIPTION
I'd like to take over PR #12 to get it across the finish line.

Per the discussion on that PR, this PR includes:

- Use 4 spaces for indentation.
- Use `throwIO` versus `error`.

**Not** includes in this PR:

- Changing `runAppToIO :: Config -> App a -> IO a` to `runAppIO :: Config -> App a -> IO (Either ServantErr a)`. 
- Using `runSqlPool` as an infix operator to avoid `$`.

@parsonsmatt Please let me know if you need other changes. The reason why I didn't do the last two changes is because I wanted to keep the changes to the original PR to a minimum, and using `runSqlPool` seemed more like a teaching moment (which I do appreciate) than anything else. goal is to get it merged though so please do let me know what changes need to happen. :-)