### PR TITLE
update to stackage lts 10.5 (ghc-8.2.2)

### DIFF
--- a/servant-persistent.cabal
+++ b/servant-persistent.cabal
@@ -77,6 +77,7 @@ library
       , ekg-core
       , katip >= 0.5.0.2 && < 0.6
       , fast-logger
+      , unordered-containers
     ghc-options:
         -fwarn-unused-imports
 

--- a/src/Api/User.hs
+++ b/src/Api/User.hs
@@ -16,7 +16,7 @@ import           Servant.JS                  (vanillaJS, writeJSForAPI)
 import           Config                      (AppT (..))
 import           Control.Monad.Metrics       (increment, metricsCounters)
 import           Data.IORef                  (readIORef)
-import           Data.Map                    (Map)
+import           Data.HashMap.Lazy           (HashMap)
 import           Data.Text                   (Text)
 import           Lens.Micro                  ((^.))
 import           Models                      (User (User), runDb, userEmail,
@@ -28,7 +28,7 @@ type UserAPI =
          "users" :> Get '[JSON] [Entity User]
     :<|> "users" :> Capture "name" Text :> Get '[JSON] (Entity User)
     :<|> "users" :> ReqBody '[JSON] User :> Post '[JSON] Int64
-    :<|> "metrics" :> Get '[JSON] (Map Text Int64)
+    :<|> "metrics" :> Get '[JSON] (HashMap Text Int64)
 
 -- | The server that runs the UserAPI
 userServer :: MonadIO m => ServerT UserAPI (AppT m)
@@ -62,7 +62,7 @@ createUser p = do
     return $ fromSqlKey newUser
 
 -- | Return wai metrics as JSON
-waiMetrics :: MonadIO m => AppT m (Map Text Int64)
+waiMetrics :: MonadIO m => AppT m (HashMap Text Int64)
 waiMetrics = do
     increment "metrics"
     logDebugNS "web" "metrics"

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-resolver: lts-9.6
+resolver: lts-10.5


### PR DESCRIPTION
I found this project to be quite a nice little example of how to set things up (especially the custom monad you are running). I am working on a similar project using the newer LTS and was having trouble getting it to compile. In the course of debugging I ended up compiling this project with the newer LTS so I figured I would go ahead and open this PR here.

Looks like the only change was that `Control.Monad.Metrics (metricsCounters)` now returns a `Data.HashMap.Lazy` instead of a `Data.Map` for a [speed increase](https://github.com/sellerlabs/monad-metrics/blob/master/CHANGELOG.md#v0200). 

I've just added a conversion of the `HashMap` to a `Map` at the end of the metric lookups. If the counter lookups are done in the `HashMap` then we will probably still get the speed increase, but we probably also still want to have the endpoint return a `Map`, since I don't think the `HashMap` has `to/fromJSON` instances.