### PR TITLE
Bump servant to .13; LTS 11.8

### DIFF
--- a/servant-persistent.cabal
+++ b/servant-persistent.cabal
@@ -61,9 +61,9 @@ library
       , persistent
       , persistent-postgresql
       , persistent-template
-      , servant >= 0.11 && < 0.12
+      , servant >= 0.13 && < 0.14
       , servant-js >= 0.9 && < 0.10
-      , servant-server >= 0.11 && < 0.12
+      , servant-server >= 0.13 && < 0.14
       , transformers
       , wai
       , wai-extra
@@ -96,8 +96,8 @@ test-suite servant-persistent-test
       , persistent
       , persistent-postgresql
       , servant-persistent
-      , servant >= 0.11 && < 0.12
-      , servant-server >= 0.11 && < 0.12
+      , servant >= 0.13 && < 0.14
+      , servant-server >= 0.13 && < 0.14
       , QuickCheck
       , hspec
       , mtl

--- a/src/Api/User.hs
+++ b/src/Api/User.hs
@@ -30,6 +30,9 @@ type UserAPI =
     :<|> "users" :> ReqBody '[JSON] User :> Post '[JSON] Int64
     :<|> "metrics" :> Get '[JSON] (HashMap Text Int64)
 
+userApi :: Proxy UserAPI
+userApi = Proxy
+
 -- | The server that runs the UserAPI
 userServer :: MonadIO m => ServerT UserAPI (AppT m)
 userServer = allUsers :<|> singleUser :<|> createUser :<|> waiMetrics

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,5 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-resolver: lts-10.5
+- katip-0.5.4.0
+resolver: lts-11.8


### PR DESCRIPTION
`enter` and the `NT` stuff are [deprecated](http://hackage.haskell.org/package/servant-0.13.0.1/docs/Servant-Utils-Enter.html) in Servant .13 and moved to a separate namespace. `hoistServer` is the new way to do this.