### PR TITLE
Implement a fast-reload ghcid based development server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+ghcid-devel:
+	ghcid \
+	    --command "stack ghci servant-persistent" \
+	    --test "DevelMain.update"
+
+.PHONY: ghcid-devel
+

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,56 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
-import qualified Control.Monad.Metrics       as M
-import           Database.Persist.Postgresql (runSqlPool)
-import           Network.Wai.Handler.Warp    (run)
-import           Network.Wai.Metrics
-import           System.Environment          (lookupEnv)
-import           System.Remote.Monitoring    (forkServer, serverMetricStore)
+import           Network.Wai.Handler.Warp (run)
 
-import           Api                         (app)
-import           Api.User                    (generateJavaScript)
-import           Config                      (Config (..), Environment (..),
-                                              makePool, setLogger)
-import           Logger                      (defaultLogEnv)
-import           Models                      (doMigrations)
-import           Safe                        (readMay)
+import           Init                     (initialize)
 
 -- | The 'main' function gathers the required environment information and
 -- initializes the application.
 main :: IO ()
 main = do
-    env  <- lookupSetting "ENV" Development
-    port <- lookupSetting "PORT" 8081
-    logEnv <- defaultLogEnv
-    pool <- makePool env logEnv
-    store <- serverMetricStore <$> forkServer "localhost" 8000
-    waiMetrics <- registerWaiMetrics store
-    metr <- M.initializeWith store
-    let cfg = Config { configPool = pool
-                     , configEnv = env
-                     , configMetrics = metr
-                     , configLogEnv = logEnv }
-        logger = setLogger env
-    runSqlPool doMigrations pool
-    generateJavaScript
-    run port $ logger $ metrics waiMetrics $ app cfg
-
--- | Looks up a setting in the environment, with a provided default, and
--- 'read's that information into the inferred type.
-lookupSetting :: Read a => String -> a -> IO a
-lookupSetting env def = do
-    maybeValue <- lookupEnv env
-    case maybeValue of
-        Nothing ->
-            return def
-        Just str ->
-            maybe (handleFailedRead str) return (readMay str)
-  where
-    handleFailedRead str =
-        error $ mconcat
-            [ "Failed to read [["
-            , str
-            , "]] for environment variable "
-            , env
-            ]
+    (port, _cfg, app) <- initialize
+    run port app

--- a/servant-persistent.cabal
+++ b/servant-persistent.cabal
@@ -47,37 +47,41 @@ library
         src
     exposed-modules:
         Config
+      , Init
       , Models
       , Api
       , Api.User
       , Logger
+      , DevelMain
     build-depends:
         base >= 4.9 && < 5.0
       , aeson
       , bytestring
+      , containers
+      , ekg
+      , ekg-core
+      , fast-logger
+      , foreign-store
+      , katip >= 0.5.0.2 && < 0.6
+      , microlens
       , monad-control
       , monad-logger
+      , monad-metrics
       , mtl
       , persistent
       , persistent-postgresql
       , persistent-template
+      , safe
       , servant >= 0.13 && < 0.14
       , servant-js >= 0.9 && < 0.10
       , servant-server >= 0.13 && < 0.14
+      , text
       , transformers
+      , unordered-containers
       , wai
       , wai-extra
-      , warp
-      , text
-      , monad-metrics
-      , ekg
       , wai-middleware-metrics
-      , microlens
-      , containers
-      , ekg-core
-      , katip >= 0.5.0.2 && < 0.6
-      , fast-logger
-      , unordered-containers
+      , warp
     ghc-options:
         -fwarn-unused-imports
 

--- a/src/DevelMain.hs
+++ b/src/DevelMain.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Running your app inside GHCi.
+--
+-- To start up GHCi for usage with Yesod, first make sure you are in dev mode:
+--
+-- > cabal configure -fdev
+--
+-- Note that @yesod devel@ automatically sets the dev flag.
+-- Now launch the repl:
+--
+-- > cabal repl --ghc-options="-O0 -fobject-code"
+--
+-- To start your app, run:
+--
+-- > :l DevelMain
+-- > DevelMain.update
+--
+-- You can also call @DevelMain.shutdown@ to stop the app
+--
+-- You will need to add the foreign-store package to your .cabal file.
+-- It is very light-weight.
+--
+-- If you don't use cabal repl, you will need
+-- to run the following in GHCi or to add it to
+-- your .ghci file.
+--
+-- :set -DDEVELOPMENT
+--
+-- There is more information about this approach,
+-- on the wiki: https://github.com/yesodweb/yesod/wiki/ghci
+
+module DevelMain where
+
+import           Prelude
+
+import           Control.Concurrent       (MVar, ThreadId, forkIO, killThread,
+                                           newEmptyMVar, putMVar, takeMVar)
+import           Control.Exception        (finally)
+import           Control.Monad            ((>=>))
+import           Data.IORef               (IORef, newIORef, readIORef,
+                                           writeIORef)
+import           Foreign.Store            (Store (..), lookupStore, readStore,
+                                           storeAction, withStore)
+import           GHC.Word                 (Word32)
+import           Network.Wai.Handler.Warp (defaultSettings, runSettings,
+                                           setPort)
+
+import           Init                     (initialize, shutdownApp)
+
+-- | Start or restart the server.
+-- newStore is from foreign-store.
+-- A Store holds onto some data across ghci reloads
+update :: IO ()
+update = do
+    mtidStore <- lookupStore tidStoreNum
+    case mtidStore of
+      -- no server running
+      Nothing -> do
+          done <- storeAction doneStore newEmptyMVar
+          tid <- start done
+          _ <- storeAction (Store tidStoreNum) (newIORef tid)
+          return ()
+      -- server is already running
+      Just tidStore -> restartAppInNewThread tidStore
+  where
+    doneStore :: Store (MVar ())
+    doneStore = Store 0
+
+    -- shut the server down with killThread and wait for the done signal
+    restartAppInNewThread :: Store (IORef ThreadId) -> IO ()
+    restartAppInNewThread tidStore = modifyStoredIORef tidStore $ \tid -> do
+        killThread tid
+        withStore doneStore takeMVar
+        readStore doneStore >>= start
+
+
+    -- | Start the server in a separate thread.
+    start :: MVar () -- ^ Written to when the thread is killed.
+          -> IO ThreadId
+    start done = do
+        (port, config, app) <- initialize
+        forkIO (finally (runSettings (setPort port defaultSettings) app)
+                        -- Note that this implies concurrency
+                        -- between shutdownApp and the next app that is starting.
+                        -- Normally this should be fine
+                        (putMVar done () >> shutdownApp config))
+
+-- | kill the server
+shutdown :: IO ()
+shutdown = do
+    mtidStore <- lookupStore tidStoreNum
+    case mtidStore of
+      -- no server running
+      Nothing -> putStrLn "no app running"
+      Just tidStore -> do
+          withStore tidStore $ readIORef >=> killThread
+          putStrLn "App is shutdown"
+
+tidStoreNum :: Word32
+tidStoreNum = 1
+
+modifyStoredIORef :: Store (IORef a) -> (a -> IO a) -> IO ()
+modifyStoredIORef store f = withStore store $ \ref -> do
+    v <- readIORef ref
+    f v >>= writeIORef ref
+
+

--- a/src/Init.hs
+++ b/src/Init.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Init where
+
+import qualified Control.Monad.Metrics       as M
+import           Database.Persist.Postgresql (runSqlPool)
+import           Network.Wai                 (Application)
+import           Network.Wai.Handler.Warp    (Port)
+import           Network.Wai.Metrics         (metrics, registerWaiMetrics)
+import           System.Environment          (lookupEnv)
+import           System.Remote.Monitoring    (forkServer, serverMetricStore)
+
+import           Api                         (app)
+import           Api.User                    (generateJavaScript)
+import           Config                      (Config (..), Environment (..),
+                                              makePool, setLogger)
+import           Logger                      (defaultLogEnv)
+import           Models                      (doMigrations)
+import           Safe                        (readMay)
+
+-- | The 'initialize' function gathers the required environment information and
+-- initializes the application, returning the port it should run on, the
+-- 'Config', and the WAI 'Application' itself.
+initialize :: IO (Port, Config, Application)
+initialize = do
+    env  <- lookupSetting "ENV" Development
+    port <- lookupSetting "PORT" 8081
+    logEnv <- defaultLogEnv
+    pool <- makePool env logEnv
+    store <- serverMetricStore <$> forkServer "localhost" 8000
+    waiMetrics <- registerWaiMetrics store
+    metr <- M.initializeWith store
+    let cfg = Config { configPool = pool
+                     , configEnv = env
+                     , configMetrics = metr
+                     , configLogEnv = logEnv }
+        logger = setLogger env
+    runSqlPool doMigrations pool
+    generateJavaScript
+    pure (port, cfg, logger $ metrics waiMetrics $ app cfg)
+
+-- | When the 'Config' gains some state that may need to be released or
+-- cleaned up, this function will take care of that.
+shutdownApp :: Config -> IO ()
+shutdownApp _ = pure ()
+
+-- | Looks up a setting in the environment, with a provided default, and
+-- 'read's that information into the inferred type.
+lookupSetting :: Read a => String -> a -> IO a
+lookupSetting env def = do
+    maybeValue <- lookupEnv env
+    case maybeValue of
+        Nothing ->
+            return def
+        Just str ->
+            maybe (handleFailedRead str) return (readMay str)
+  where
+    handleFailedRead str =
+        error $ mconcat
+            [ "Failed to read [["
+            , str
+            , "]] for environment variable "
+            , env
+            ]
+


### PR DESCRIPTION
This PR implements a new REPL command:

```
$ make ghcid-devel
```

Which loads the `servant-persistent` application in a background thread. When you edit your files or change anyhting, the server process is killed and restarted in GHCi, so it is *lightning* fast compared to a full `stack build` and linking all the executables.