### PR TITLE
Use resource management for Config

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,15 +1,8 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Main where
 
-import           Network.Wai.Handler.Warp (run)
-import           Config                   (configPort)
-import           Init                     (initialize, acquireConfig)
+import           Init                     (runApp)
 
 -- | The 'main' function gathers the required environment information and
 -- initializes the application.
 main :: IO ()
-main = do
-    cfg <- acquireConfig
-    app <- initialize cfg
-    run (configPort cfg) app
+main = runApp

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,12 +3,13 @@
 module Main where
 
 import           Network.Wai.Handler.Warp (run)
-
-import           Init                     (initialize)
+import           Config                   (configPort)
+import           Init                     (initialize, acquireConfig)
 
 -- | The 'main' function gathers the required environment information and
 -- initializes the application.
 main :: IO ()
 main = do
-    (port, _cfg, app) <- initialize
-    run port app
+    cfg <- acquireConfig
+    app <- initialize cfg
+    run (configPort cfg) app

--- a/servant-persistent.cabal
+++ b/servant-persistent.cabal
@@ -82,6 +82,7 @@ library
       , wai-extra
       , wai-middleware-metrics
       , warp
+      , resource-pool
     ghc-options:
         -fwarn-unused-imports
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Config where
 
 import           Control.Exception                    (throwIO)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -23,6 +23,7 @@ import           Network.Wai                          (Middleware)
 import           Network.Wai.Middleware.RequestLogger (logStdout, logStdoutDev)
 import           Servant                              (ServantErr)
 import           System.Environment                   (lookupEnv)
+import           Network.Wai.Handler.Warp             (Port)
 
 import           Logger
 
@@ -49,6 +50,7 @@ data Config
     , configEnv     :: Environment
     , configMetrics :: Metrics
     , configLogEnv  :: LogEnv
+    , configPort    :: Port
     }
 
 instance Monad m => MonadMetrics (AppT m) where

--- a/src/DevelMain.hs
+++ b/src/DevelMain.hs
@@ -30,7 +30,8 @@ import           GHC.Word                 (Word32)
 import           Network.Wai.Handler.Warp (defaultSettings, runSettings,
                                            setPort)
 
-import           Init                     (initialize, shutdownApp)
+import           Init                     (initialize, shutdownApp, acquireConfig)
+import           Config                   (configPort)
 
 -- | Start or restart the server.
 -- newStore is from foreign-store.
@@ -63,7 +64,9 @@ update = do
     start :: MVar () -- ^ Written to when the thread is killed.
           -> IO ThreadId
     start done = do
-        (port, config, app) <- initialize
+        config <- acquireConfig
+        app <- initialize config
+        let port = configPort config
         forkIO (finally (runSettings (setPort port defaultSettings) app)
                         -- Note that this implies concurrency
                         -- between shutdownApp and the next app that is starting.

--- a/src/DevelMain.hs
+++ b/src/DevelMain.hs
@@ -27,11 +27,7 @@ import           Data.IORef               (IORef, newIORef, readIORef,
 import           Foreign.Store            (Store (..), lookupStore, readStore,
                                            storeAction, withStore)
 import           GHC.Word                 (Word32)
-import           Network.Wai.Handler.Warp (defaultSettings, runSettings,
-                                           setPort)
-
-import           Init                     (initialize, shutdownApp, acquireConfig)
-import           Config                   (configPort)
+import           Init                     (runApp)
 
 -- | Start or restart the server.
 -- newStore is from foreign-store.
@@ -63,15 +59,12 @@ update = do
     -- | Start the server in a separate thread.
     start :: MVar () -- ^ Written to when the thread is killed.
           -> IO ThreadId
-    start done = do
-        config <- acquireConfig
-        app <- initialize config
-        let port = configPort config
-        forkIO (finally (runSettings (setPort port defaultSettings) app)
+    start done =
+        forkIO (finally runApp
                         -- Note that this implies concurrency
                         -- between shutdownApp and the next app that is starting.
                         -- Normally this should be fine
-                        (putMVar done () >> shutdownApp config))
+                        (putMVar done ()))
 
 -- | kill the server
 shutdown :: IO ()

--- a/src/Init.hs
+++ b/src/Init.hs
@@ -16,6 +16,16 @@ import           Config                      (Config (..), Environment (..),
 import           Logger                      (defaultLogEnv)
 import           Models                      (doMigrations)
 import           Safe                        (readMay)
+import           Control.Exception           (bracket)
+import           Network.Wai.Handler.Warp    (run)
+
+
+-- | An action that creates WAI 'Application' together with its resources
+--   and tears it down on exit
+runApp :: IO ()
+runApp = bracket acquireConfig shutdownApp runApp
+  where
+    runApp config = run (configPort config) =<< initialize config
 
 -- | The 'initialize' function gathers the required environment information and
 -- initializes the WAI 'Application' and returns it
@@ -48,7 +58,7 @@ acquireConfig = do
 -- | When the 'Config' gains some state that may need to be released or
 -- cleaned up, this function will take care of that.
 shutdownApp :: Config -> IO ()
-shutdownApp _ = pure () -- todo: release resources allocated in openConfig
+shutdownApp _ = pure () -- todo: release resources allocated in acquireConfig
 
 -- | Looks up a setting in the environment, with a provided default, and
 -- 'read's that information into the inferred type.


### PR DESCRIPTION
This is a first stab at resolving #26.
Although `runApp` function it introduces does not have requested type (`runApp :: (MonadIO m, MonadMask m) => AppT m a -> m a`), it does use `bracket` for Config resource allocation/deallocation, so it is, hopefully, a step in the right direction.