### PR TITLE
Add instructions on how to use docker to run postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,14 @@ sudo usermod -aG docker <username>
 
 After the installation, restart your terminal and the installation is complete.
 
-You'll also need to install docker compose seperately. To install it, run the
-command below.
+You'll also need to install docker compose seperately. To install it, run the command below.
 
 ```terminal
 sudo curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 ```
 
-If you can check if the installation was successful by running `docker-compose --version`.
+To check if the installation was successful, run command `docker-compose --version`.
 
 To run the postgresql, run `docker-compose up -d` which docker will run postgresql
 on the background. After you're done using it, run `docker-compose down` to take

--- a/README.md
+++ b/README.md
@@ -75,6 +75,50 @@ Type "help" for help.
 perservant=#
 ```
 
+You can also use [docker](https://www.docker.com/) to run the database which 
+let you use postgresql without ever installing it on your machine.
+
+If you're using Linux and want to install docker, there's a script that Docker
+is providing which you can use to install everything you need with few commands.
+
+https://get.docker.com/
+
+Basically, you need to run the command below.
+
+```terminal
+curl -fsSL get.docker.com -o get-docker.sh
+sh get-docker.sh
+sudo usermod -aG docker <username>
+```
+
+After the installation, restart your terminal and the installation is complete.
+
+The most easiest way to run postgresql is to use docker-compose.
+Here's an example of an `docker-compose.yml` file.
+
+```docker-compose.yml
+version: '3.1'
+
+services:
+  postgres:
+    image: postgres
+    ports:
+      - '127.0.0.1:5432:5432'
+    environment:
+      - POSTGRES_PASSWORD=test
+      - POSTGRES_USER=test
+      - POSTGRES_DB=perservant
+    volumes:
+      - perservant-db:/var/lib/postgresql/data:rw
+
+volumes:
+  perservant-db:
+```
+
+To run the postgresql, run `docker-compose up`. After you're done using it, run
+`docker-compose down` to take it down entirely. Note that the data will persist
+until you've deleted the volume.
+
 ## The API:
 
 - GET `/users` returns a list of all users in the database

--- a/README.md
+++ b/README.md
@@ -93,9 +93,19 @@ sudo usermod -aG docker <username>
 
 After the installation, restart your terminal and the installation is complete.
 
-To run the postgresql, run `docker-compose up -d` which docker will run postgresql on the background.
-After you're done using it, run `docker-compose down` to take it down entirely.
-Note that the data will persist until you've deleted the volume.
+You'll also need to install docker compose seperately. To install it, run the
+command below.
+
+```terminal
+sudo curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+If you can check if the installation was successful by running `docker-compose --version`.
+
+To run the postgresql, run `docker-compose up -d` which docker will run postgresql
+on the background. After you're done using it, run `docker-compose down` to take
+it down entirely. Note that the data will persist until you've deleted the volume.
 
 ## The API:
 

--- a/README.md
+++ b/README.md
@@ -93,31 +93,9 @@ sudo usermod -aG docker <username>
 
 After the installation, restart your terminal and the installation is complete.
 
-The most easiest way to run postgresql is to use docker-compose.
-Here's an example of an `docker-compose.yml` file.
-
-```docker-compose.yml
-version: '3.1'
-
-services:
-  postgres:
-    image: postgres
-    ports:
-      - '127.0.0.1:5432:5432'
-    environment:
-      - POSTGRES_PASSWORD=test
-      - POSTGRES_USER=test
-      - POSTGRES_DB=perservant
-    volumes:
-      - perservant-db:/var/lib/postgresql/data:rw
-
-volumes:
-  perservant-db:
-```
-
-To run the postgresql, run `docker-compose up`. After you're done using it, run
-`docker-compose down` to take it down entirely. Note that the data will persist
-until you've deleted the volume.
+To run the postgresql, run `docker-compose up -d` which docker will run postgresql on the background.
+After you're done using it, run `docker-compose down` to take it down entirely.
+Note that the data will persist until you've deleted the volume.
 
 ## The API:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.1'
+
+services:
+  postgres:
+    image: postgres
+    ports:
+      - '127.0.0.1:5432:5432'
+    environment:
+      - POSTGRES_PASSWORD=test
+      - POSTGRES_USER=test
+      - POSTGRES_DB=perservant
+    volumes:
+      - perservant-db:/var/lib/postgresql/data:rw
+
+volumes:
+  perservant-db:


### PR DESCRIPTION
Add instruction on how to use Docker to run postgresql. 
This is much nicer since you can use postgresql without ever installing it on their local machine.

@parsonsmatt If you're interested, I can also, add `docker-compose.yml` file to the repo as well!